### PR TITLE
Update Chef Infra Client to version 15.6.10

### DIFF
--- a/chef/chef.nuspec
+++ b/chef/chef.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/chef/chef</projectSourceUrl>
     <projectUrl>https://github.com/chef/chef/</projectUrl>
-    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v15.5.17/RELEASE_NOTES.md)</releaseNotes>
-    <version>15.5.17</version>
+    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v15.6.10/RELEASE_NOTES.md)</releaseNotes>
+    <version>15.6.10</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/chef/tools/chocolateyinstall.ps1
+++ b/chef/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$version = '15.5.17'
+$version = '15.6.10'
 
 $packageArgs = @{
     packageName    = 'chef-client'
@@ -7,9 +7,9 @@ $packageArgs = @{
     url64          = "https://packages.chef.io/files/stable/chef/$version/windows/2012r2/chef-client-$version-1-x64.msi"
     silentArgs     = '/quiet'
     validExitCodes = @(0)
-    checksum       = '3b1aea92f6596e75e2b244dfdf88d5045ef20ff326a86667025c81057c8a67f6'
+    checksum       = '551171d2f83b8926d62f173098914de81291fff8bf7ab61336e4cff0bcb5baaf'
     checksumType   = 'sha256'
-    checksum64     = 'e728a43fcadcc0fa7979c879ad6aa692a53492d93e8cc0c6752d6d0bd030a7fd'
+    checksum64     = '5553cea94fc5c374403751324619802509b906ef8e2b92a36a5fc71b35dbb1e2'
     checksumType64 = 'sha256'
 }
 


### PR DESCRIPTION
### Description

Update Chef Infra Client to version [15.6.10](https://downloads.chef.io/chef/stable/15.6.10#windows).

### Issues Resolved

n/a

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG