### PR TITLE
updated chef to 16.3.45, chefdk to 4.10.0 and inspec to 4.22.1

### DIFF
--- a/chef/chef.nuspec
+++ b/chef/chef.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/chef/chef</projectSourceUrl>
     <projectUrl>https://github.com/chef/chef/</projectUrl>
-    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v16.1.6/RELEASE_NOTES.md)</releaseNotes>
-    <version>16.1.6</version>
+    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v16.3.45/RELEASE_NOTES.md)</releaseNotes>
+    <version>16.3.45</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/chef/tools/chocolateyinstall.ps1
+++ b/chef/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$version = '16.1.6'
+$version = '16.3.45'
 
 $packageArgs = @{
     packageName    = 'chef-client'
@@ -7,9 +7,9 @@ $packageArgs = @{
     url64          = "https://packages.chef.io/files/stable/chef/$version/windows/2012r2/chef-client-$version-1-x64.msi"
     silentArgs     = '/quiet'
     validExitCodes = @(0)
-    checksum       = '68d7b0020bdc90c4af52cacd82c7e219f93898e54078ef78505a036112fe3e5c'
+    checksum       = 'e5388da8df7f66c5e12960c7598ade0d64756f22f7160ae661c66b51c657ca52'
     checksumType   = 'sha256'
-    checksum64     = '19be54232bbf7503af9c236944b2fd6d72089be370f30e74eed7f6e1ef396cd4'
+    checksum64     = 'e50272e4e9959210fe5698f1e134f5c612d7ed000c0400dd2b440e1e8bb8c0bb'
     checksumType64 = 'sha256'
 }
 

--- a/chefdk/chefdk.nuspec
+++ b/chefdk/chefdk.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/chef/chef-dk</projectSourceUrl>
     <projectUrl>https://github.com/chef/chef-dk/</projectUrl>
-    <releaseNotes>[Release Notes](https://github.com/chef/chef-dk/blob/v4.8.23/RELEASE_NOTES.md)</releaseNotes>
-    <version>4.8.23</version>
+    <releaseNotes>[Release Notes](https://github.com/chef/chef-dk/blob/v4.10.0/RELEASE_NOTES.md)</releaseNotes>
+    <version>4.10.0</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/chefdk/tools/chocolateyinstall.ps1
+++ b/chefdk/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$version = '4.8.23'
+$version = '4.10.0'
 $url = "https://packages.chef.io/files/stable/chefdk/$version/windows/2012r2/chefdk-$version-1-x86.msi"
 $url64 = "https://packages.chef.io/files/stable/chefdk/$version/windows/2012r2/chefdk-$version-1-x64.msi"
 
@@ -8,9 +8,9 @@ $packageArgs = @{
     fileType       = 'MSI'
     url            = $url
     url64bit       = $url64
-    checksum       = '2034e7144d97c70f8739ab936bcf2e780c2a31b815d0e502c6a80e6ae11eef5f'
+    checksum       = '0b021c6b53689e9db997022308b57f46660ac3d0070148a17d3660f496284140'
     checksumType   = 'sha256'
-    checksum64     = 'bd092de8f1c42f797fa20813c9a8b5ede7886386d4aefb6fe5403cb173b3b598'
+    checksum64     = '03dd82c50c6425e3cdc55ada277676ec982203623d4f5d7a6e7227527fdb81bc'
     checksumType64 = 'sha256'
     silentArgs     = "/qn /quiet /norestart"
     validExitCodes = @(0, 3010)

--- a/inspec/inspec.nuspec
+++ b/inspec/inspec.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/inspec/inspec</projectSourceUrl>
     <projectUrl>https://github.com/inspec/inspec/</projectUrl>
-    <releaseNotes>[Changelog](https://github.com/inspec/inspec/blob/v4.19.0/CHANGELOG.md)</releaseNotes>
-    <version>4.19.0</version>
+    <releaseNotes>[Changelog](https://github.com/inspec/inspec/blob/v4.22.1/CHANGELOG.md)</releaseNotes>
+    <version>4.22.1</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/inspec/tools/chocolateyinstall.ps1
+++ b/inspec/tools/chocolateyinstall.ps1
@@ -1,11 +1,11 @@
-$version = '4.19.0'
+$version = '4.22.1'
 
 $packageArgs = @{
     packageName    = 'inspec'
     unzipLocation  = $toolsDir
     fileType       = 'msi'
     url64bit       = "https://packages.chef.io/files/stable/inspec/$version/windows/2016/inspec-$version-1-x64.msi"
-    checksum64     = 'f4c5e05d63e794edce5155128055965237121d2787b93290884bd9e4ec7e780a'
+    checksum64     = '1c3750aa81f7b5f6862b91401780d69777a05c9654c3a4c0e52331c48d70066c'
     checksumType64 = 'sha256'
     silentArgs     = "/qn /quiet /norestart"
     validExitCodes = @(0, 3010)


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

### Description

Updated to latest versions

### Issues Resolved



### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG