### PR TITLE
Updated Chef to 16.5.77, Chefdk to 4.11.0, Inspec to 4.23.11

### DIFF
--- a/chef/chef.nuspec
+++ b/chef/chef.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/chef/chef</projectSourceUrl>
     <projectUrl>https://github.com/chef/chef/</projectUrl>
-    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v16.3.45/RELEASE_NOTES.md)</releaseNotes>
-    <version>16.3.45</version>
+    <releaseNotes>[Release Notes](https://github.com/chef/chef/blob/v16.5.77/RELEASE_NOTES.md)</releaseNotes>
+    <version>16.5.77</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/chef/tools/chocolateyinstall.ps1
+++ b/chef/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$version = '16.3.45'
+$version = '16.5.77'
 
 $packageArgs = @{
     packageName    = 'chef-client'
@@ -7,9 +7,9 @@ $packageArgs = @{
     url64          = "https://packages.chef.io/files/stable/chef/$version/windows/2012r2/chef-client-$version-1-x64.msi"
     silentArgs     = '/quiet'
     validExitCodes = @(0)
-    checksum       = 'e5388da8df7f66c5e12960c7598ade0d64756f22f7160ae661c66b51c657ca52'
+    checksum       = 'b6d559ca63536ca8ca5a8a615ee486eeab7ab472ea6963241fe3269419f621d9'
     checksumType   = 'sha256'
-    checksum64     = 'e50272e4e9959210fe5698f1e134f5c612d7ed000c0400dd2b440e1e8bb8c0bb'
+    checksum64     = '5d7622cf586885ac1ab6f416d8f09424472dd9b9231f58655b5d110670c77e64'
     checksumType64 = 'sha256'
 }
 

--- a/chefdk/chefdk.nuspec
+++ b/chefdk/chefdk.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/chef/chef-dk</projectSourceUrl>
     <projectUrl>https://github.com/chef/chef-dk/</projectUrl>
-    <releaseNotes>[Release Notes](https://github.com/chef/chef-dk/blob/v4.10.0/RELEASE_NOTES.md)</releaseNotes>
-    <version>4.10.0</version>
+    <releaseNotes>[Release Notes](https://github.com/chef/chef-dk/blob/v4.11.0/RELEASE_NOTES.md)</releaseNotes>
+    <version>4.11.0</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/chefdk/tools/chocolateyinstall.ps1
+++ b/chefdk/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-$version = '4.10.0'
+$version = '4.11.0'
 $url = "https://packages.chef.io/files/stable/chefdk/$version/windows/2012r2/chefdk-$version-1-x86.msi"
 $url64 = "https://packages.chef.io/files/stable/chefdk/$version/windows/2012r2/chefdk-$version-1-x64.msi"
 
@@ -8,9 +8,9 @@ $packageArgs = @{
     fileType       = 'MSI'
     url            = $url
     url64bit       = $url64
-    checksum       = '0b021c6b53689e9db997022308b57f46660ac3d0070148a17d3660f496284140'
+    checksum       = '267a289fe17f3bffeebf641250567a5a70574108372a74b1edc63cbb79485a7f'
     checksumType   = 'sha256'
-    checksum64     = '03dd82c50c6425e3cdc55ada277676ec982203623d4f5d7a6e7227527fdb81bc'
+    checksum64     = 'bd4c6ccb692a50248e7e97a763593017f7defbd3fdafa6e7380650f08e2d9914'
     checksumType64 = 'sha256'
     silentArgs     = "/qn /quiet /norestart"
     validExitCodes = @(0, 3010)

--- a/inspec/inspec.nuspec
+++ b/inspec/inspec.nuspec
@@ -18,8 +18,8 @@
     <packageSourceUrl>https://github.com/chef/chocolatey-packages/</packageSourceUrl>
     <projectSourceUrl>https://github.com/inspec/inspec</projectSourceUrl>
     <projectUrl>https://github.com/inspec/inspec/</projectUrl>
-    <releaseNotes>[Changelog](https://github.com/inspec/inspec/blob/v4.22.8/CHANGELOG.md)</releaseNotes>
-    <version>4.22.8</version>
+    <releaseNotes>[Changelog](https://github.com/inspec/inspec/blob/v4.23.11/CHANGELOG.md)</releaseNotes>
+    <version>4.23.11</version>
   </metadata>
   <files>
     <file src="tools\**" target="tools"/>

--- a/inspec/tools/chocolateyinstall.ps1
+++ b/inspec/tools/chocolateyinstall.ps1
@@ -1,11 +1,11 @@
-$version = '4.22.8'
+$version = '4.23.11'
 
 $packageArgs = @{
     packageName    = 'inspec'
     unzipLocation  = $toolsDir
     fileType       = 'msi'
     url64bit       = "https://packages.chef.io/files/stable/inspec/$version/windows/2016/inspec-$version-1-x64.msi"
-    checksum64     = 'e8261f14285ec72d729ab986ba907e0815ea3c2a0ea2dad1d48054f92ab857be'
+    checksum64     = 'b9e96c10d577989218b43152f404cdf8a6487f7532be2c96bdd61fbc104a571f'
     checksumType64 = 'sha256'
     silentArgs     = "/qn /quiet /norestart"
     validExitCodes = @(0, 3010)


### PR DESCRIPTION
### Description
Updated Chef to 16.5.77, Chefdk to 4.11.0, Inspec to 4.23.11

### Issues Resolved

Pushed latest versions of listed chef software

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG